### PR TITLE
PayPal Standard is non-standard

### DIFF
--- a/api/v3/NotificationLog/Retry.php
+++ b/api/v3/NotificationLog/Retry.php
@@ -41,6 +41,9 @@ function _civicrm_api3_notification_log_process($logEntry) {
   if (substr($logEntry['message'], 0, 36) == 'payment_notification processor_name=') {
     $processorName = substr($logEntry['message'], 36);
   }
+  elseif ($logEntry['message'] == 'payment_notification PayPal_Standard') {
+    $processorName = 'PayPal_Standard';
+  }
   elseif (substr($logEntry['message'], 0, 34) == 'payment_notification processor_id=') {
     $processorId = substr($logEntry['message'], 34);
     $processorTypeId = civicrm_api3('PaymentProcessor', 'getvalue', array('id' => $processorId, 'return' => 'payment_processor_type_id'));
@@ -49,7 +52,6 @@ function _civicrm_api3_notification_log_process($logEntry) {
   else {
     throw new API_Exception('unsupported processor');
   }
-  echo $processorName;
   // Build the parameter array for the IPN class.
   $ipnParams = array_merge(json_decode($logEntry['context'], TRUE), array('receive_date' => $logEntry['timestamp']));
   if ($processorId) {


### PR DESCRIPTION
So I had a bit of trouble retrying PayPal Standard payments tonight - because PayPal Standard omits the `processor_name=` portion of the `message` field in `civicrm_system_log` (see below).  It also looks like I left a debug statement in when I last touched this file.  Anyway, here's a fix.  A bit hacky, but actually the exact right amount of hacky for the situation IMO.
```
MariaDB [mysite]> select message from civicrm_system_log GROUP BY message;                                                                                                                                                         
+---------------------------------------------+
| message                                     |
+---------------------------------------------+
| payment_notification PayPal_Standard        |
| payment_notification processor_id=1         |
| payment_notification processor_id=3         |
| payment_notification processor_name=AuthNet |
| payment_notification processor_name=PayPal  |
+---------------------------------------------+
```