### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/NotificationLog/Process.php
+++ b/api/v3/NotificationLog/Process.php
@@ -8,8 +8,8 @@
  *
  * @return array
  *   API result array
- * @throws \API_Exception
- * @throws \CiviCRM_API3_Exception
+ * @throws \CRM_Core_Exception
+ * @throws \CRM_Core_Exception
  */
 function civicrm_api3_notification_log_process($params) {
   $processLogParams = array(
@@ -25,7 +25,7 @@ function civicrm_api3_notification_log_process($params) {
     try {
       civicrm_api3('NotificationLog', 'retry', array('system_log_id' => $values['id']));
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       if ($e->getMessage() == 'DB Error: already exists') {
         $logs['values'][$id]['already_processed'] = TRUE;
       }

--- a/api/v3/NotificationLog/Restorecontribution.php
+++ b/api/v3/NotificationLog/Restorecontribution.php
@@ -10,8 +10,8 @@
  *
  * @return array
  *   API result array
- * @throws \API_Exception
- * @throws \CiviCRM_API3_Exception
+ * @throws \CRM_Core_Exception
+ * @throws \CRM_Core_Exception
  */
 function civicrm_api3_notification_log_restorecontribution($params) {
   $queryParams = array(1 => array($params['id'], 'Integer'));

--- a/api/v3/NotificationLog/Retry.php
+++ b/api/v3/NotificationLog/Retry.php
@@ -9,8 +9,8 @@
  *
  * @return array
  *   API result array
- * @throws \API_Exception
- * @throws \CiviCRM_API3_Exception
+ * @throws \CRM_Core_Exception
+ * @throws \CRM_Core_Exception
  */
 function civicrm_api3_notification_log_retry($params) {
   if (!empty($params['system_log_id'])) {
@@ -24,7 +24,7 @@ function civicrm_api3_notification_log_retry($params) {
     if (_civicrm_api3_notification_log_process($logEntry)) {
       return civicrm_api3_create_success(1, $params);
     }
-    throw new API_Exception('payment retry failed');
+    throw new CRM_Core_Exception('payment retry failed');
   }
 }
 
@@ -34,7 +34,7 @@ function civicrm_api3_notification_log_retry($params) {
  * @param array $logEntry
  *
  * @return bool
- * @throws \API_Exception
+ * @throws \CRM_Core_Exception
  */
 function _civicrm_api3_notification_log_process($logEntry) {
   // Determine which style of IPN we're using and get the processor name.
@@ -50,7 +50,7 @@ function _civicrm_api3_notification_log_process($logEntry) {
     $processorName = civicrm_api3('PaymentProcessorType', 'getvalue', array('id' => $processorTypeId, 'return' => 'name'));
   }
   else {
-    throw new API_Exception('unsupported processor');
+    throw new CRM_Core_Exception('unsupported processor');
   }
   // Build the parameter array for the IPN class.
   $ipnParams = array_merge(json_decode($logEntry['context'], TRUE), array('receive_date' => $logEntry['timestamp']));
@@ -72,7 +72,7 @@ function _civicrm_api3_notification_log_process($logEntry) {
       break;
 
     default:
-      throw new API_Exception('unsupported processor');
+      throw new CRM_Core_Exception('unsupported processor');
   }
   $ipnClass->main();
   return TRUE;

--- a/api/v3/NotificationLog/Retryfromcsv.php
+++ b/api/v3/NotificationLog/Retryfromcsv.php
@@ -9,7 +9,7 @@ function _civicrm_api3_notification_log_retryfromcsv_spec(&$params) {
 function civicrm_api3_notification_log_retryfromcsv($params) {
   $csv_file = file($params['csv']);
   if ($csv_file === FALSE) {
-    throw new API_Exception('an error occurred reading from CSV file');
+    throw new CRM_Core_Exception('an error occurred reading from CSV file');
   }
 
   $logs = array_map('str_getcsv', $csv_file);


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.